### PR TITLE
Add dependency exclusion for jackson dataformat lib. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,9 +55,11 @@ dependencies {
     compile "org.slf4j:slf4j-api:1.7.30"
     pluginLibs ('com.amazonaws:aws-java-sdk-s3:1.11.743') {
         exclude group: "com.fasterxml.jackson.core"
+        exclude group: "com.fasterxml.jackson.dataformat"
     }
     pluginLibs ('com.amazonaws:aws-java-sdk-sts:1.11.743') {
         exclude group: "com.fasterxml.jackson.core"
+        exclude group: "com.fasterxml.jackson.dataformat"
     }
 
     testCompile "org.codehaus.groovy:groovy-all:2.3.7"


### PR DESCRIPTION
The lib bundled in Rundeck should be used instead.

The version used in the aws lib has a CVE reported against it.