### PR TITLE
RUN-1781: Update aws-java-sdk-s3 to fix CVE-2022-31159

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ configurations {
 dependencies {
     compile group: 'org.rundeck', name: 'rundeck-core', version: '2.10.0'
     compile "org.slf4j:slf4j-api:1.7.30"
-    pluginLibs ('com.amazonaws:aws-java-sdk-s3:1.11.743') {
+    pluginLibs ('com.amazonaws:aws-java-sdk-s3:1.12.479') {
         exclude group: "com.fasterxml.jackson.core"
         exclude group: "com.fasterxml.jackson.dataformat"
     }


### PR DESCRIPTION
Update aws-java-sdk-s3 lib to 1.12.479