### PR TITLE
RUN-2312 : Update aws-java-sdk-s3 to fix CVE-2024-21634

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ configurations {
 dependencies {
     implementation group: 'org.rundeck', name: 'rundeck-core', version: '4.13.0-20230515'
     implementation "org.slf4j:slf4j-api:1.7.30"
-    pluginLibs ('com.amazonaws:aws-java-sdk-s3:1.12.479') {
+    pluginLibs ('com.amazonaws:aws-java-sdk-s3:1.12.708') {
         exclude group: "com.fasterxml.jackson.core"
         exclude group: "com.fasterxml.jackson.dataformat"
     }


### PR DESCRIPTION
Update the version of the aws-java-sdk-s3 library to the one that does not reference the ion-java:1.0.2 dependency that has the [CVE-2024-21634](https://nvd.nist.gov/vuln/detail/CVE-2024-21634) vulnerability