### PR TITLE
RUN-3601: CVE-2025-48924 Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
     }
     implementation libs.slf4jApi
     
+    // Add secure commons-lang3 to provide alternative to vulnerable commons-lang 2.6
+    implementation(libs.commonsLang3)
+    
     pluginLibs(libs.awsSdkS3) {
         exclude group: "com.fasterxml.jackson.core"
         exclude group: "com.fasterxml.jackson.dataformat"
@@ -60,6 +63,15 @@ dependencies {
     }
 
     testImplementation libs.bundles.testLibs
+}
+
+configurations.all {
+    resolutionStrategy {
+        // Replace vulnerable commons-lang with secure commons-lang3
+        dependencySubstitution {
+            substitute module('commons-lang:commons-lang') using module("org.apache.commons:commons-lang3:${libs.versions.commonsLang3.get()}")
+        }
+    }
 }
 
 task copyToLib(type: Copy) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,8 @@ cglib = "2.2.2"
 byteBuddy = "1.14.12"
 objenesis = "1.4"
 slf4j = "1.7.30"
+# Security overrides for transitive dependencies
+commonsLang3 = "3.18.0"
 
 [libraries]
 rundeckCore = { group = "org.rundeck", name = "rundeck-core", version.ref = "rundeckCore" }
@@ -20,6 +22,7 @@ cglibNodep = { group = "cglib", name = "cglib-nodep", version.ref = "cglib" }
 objenesis = { group = "org.objenesis", name = "objenesis", version.ref = "objenesis" }
 byteBuddy = { group = "net.bytebuddy", name = "byte-buddy", version.ref = "byteBuddy" }
 slf4jApi = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
+commonsLang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commonsLang3" }
 
 [bundles]
 testLibs = ["groovyAll", "spockCore", "cglibNodep", "objenesis", "byteBuddy"]


### PR DESCRIPTION
Mitigates CVE-2025-48924 by upgrading commons-lang to commons-lang3 3.18.0.

**Changes:**
- Added commons-lang3 3.18.0 dependency to libs.versions.toml
- Configured dependency substitution to replace vulnerable commons-lang with secure commons-lang3
- Ensures all transitive dependencies use the secure version

**Security Impact:**
This change addresses the security vulnerability identified in CVE-2025-48924 by replacing the vulnerable commons-lang 2.x library with the secure commons-lang3 3.18.0 version.