### PR TITLE
[RUN-4638] Migrate publishing from Maven Central to PackageCloud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to PackageCloud
-        run: ./gradlew publishAllPublicationsToPackageCloudRepository
+        run: |
+          if [ -z "$PKGCLD_REPO_URL" ] || [ -z "$PKGCLD_WRITE_TOKEN" ]; then
+            echo "::error::PKGCLD_REPO_URL and PKGCLD_WRITE_TOKEN must both be set to publish to PackageCloud"
+            exit 1
+          fi
+          ./gradlew publishAllPublicationsToPackageCloudRepository
         env:
           PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to PackageCloud
         run: |
-          if [ -z "$PKGCLD_REPO_URL" ] || [ -z "$PKGCLD_WRITE_TOKEN" ]; then
-            echo "::error::PKGCLD_REPO_URL and PKGCLD_WRITE_TOKEN must both be set to publish to PackageCloud"
+          if [ -z "$PKGCLD_WRITE_TOKEN" ]; then
+            echo "::error::PKGCLD_WRITE_TOKEN must be set to publish to PackageCloud"
             exit 1
           fi
           ./gradlew publishAllPublicationsToPackageCloudRepository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: Publish Release
     runs-on: ubuntu-latest
+    env:
+      PKGCLD_REPO_URL: ${{ vars.PKGCLD_REPO_URL }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -35,10 +37,7 @@ jobs:
             build/libs/aws-s3-model-source-${{ steps.get_version.outputs.VERSION }}.jar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish to Maven Central
-        run: ./gradlew -PsigningKey=${SIGNING_KEY_B64} -PsigningPassword=${SIGNING_PASSWORD} -PsonatypeUsername=${SONATYPE_USERNAME} -PsonatypePassword=${SONATYPE_PASSWORD} publishToSonatype closeAndReleaseSonatypeStagingRepository
+      - name: Publish to PackageCloud
+        run: ./gradlew publishAllPublicationsToPackageCloudRepository
         env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SIGNING_KEY_B64: ${{ secrets.SIGNING_KEY_B64 }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,3 +46,29 @@ jobs:
           ./gradlew publishAllPublicationsToPackageCloudRepository
         env:
           PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}
+      - name: Sign and upload GPG signatures to PackageCloud
+        run: |
+          set -e
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          BASE_URL="${PKGCLD_REPO_URL:-https://packagecloud.io/pagerduty/rundeck-plugins/maven2}/org/rundeck/plugins/aws-s3-model-source/${VERSION}"
+
+          echo "$SIGNING_KEY_B64" | base64 -d | gpg --batch --yes --import
+          KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/ {print $5; exit}')
+
+          sign_and_upload() {
+            local FILE="$1"
+            local REMOTE_NAME="$2"
+            gpg --batch --yes --pinentry-mode loopback --passphrase "$SIGNING_PASSWORD" --default-key "$KEY_ID" --detach-sign --armor "$FILE"
+            curl -sf -H "Authorization: Bearer ${PKGCLD_WRITE_TOKEN}" \
+              -X PUT --data-binary "@${FILE}.asc" \
+              "${BASE_URL}/${REMOTE_NAME}.asc"
+          }
+
+          sign_and_upload "build/libs/aws-s3-model-source-${VERSION}.jar" "aws-s3-model-source-${VERSION}.jar"
+          sign_and_upload "build/libs/aws-s3-model-source-${VERSION}-sources.jar" "aws-s3-model-source-${VERSION}-sources.jar"
+          sign_and_upload "build/libs/aws-s3-model-source-${VERSION}-javadoc.jar" "aws-s3-model-source-${VERSION}-javadoc.jar"
+          sign_and_upload "build/publications/aws-s3-model-source/pom-default.xml" "aws-s3-model-source-${VERSION}.pom"
+        env:
+          SIGNING_KEY_B64: ${{ secrets.SIGNING_KEY_B64 }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'groovy'
     id 'idea'
     alias(libs.plugins.axionRelease)
-    alias(libs.plugins.nexusPublish)
 }
 
 group = 'org.rundeck.plugins'
@@ -122,16 +121,6 @@ test {
         '--add-opens=java.base/java.util=ALL-UNNAMED',
         '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED'
     ]
-}
-
-nexusPublishing {
-    packageGroup = 'org.rundeck.plugins'
-    repositories {
-        sonatype {
-            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
-        }
-    }
 }
 
 apply from: "${rootDir}/gradle/publishing.gradle"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 axionRelease = "1.21.2"
 groovy = "4.0.32"
 rundeckCore = "6.1.0-SNAPSHOT"
-nexusPublish = "2.0.0"
 spock = "2.4-groovy-4.0"
 awsSdk = "1.12.797"
 cglib = "3.3.0"
@@ -29,4 +28,3 @@ testLibs = ["groovyAll", "spockCore", "cglibNodep", "objenesis", "byteBuddy"]
 
 [plugins]
 axionRelease = { id = "pl.allegro.tech.build.axion-release", version.ref = "axionRelease" }
-nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublish" }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -8,7 +8,7 @@
  */
 apply plugin: 'maven-publish'
 
-def pkgcldRepoUrl = System.getenv("PKGCLD_REPO_URL")?.trim()
+def pkgcldRepoUrl = (System.getenv("PKGCLD_REPO_URL") ?: "https://packagecloud.io/pagerduty/rundeck-plugins/maven2").trim()
 
 publishing {
     publications {
@@ -48,19 +48,15 @@ publishing {
         }
     }
     repositories {
-        // Only register the PackageCloud repo when its URL is configured, so plain
-        // builds/tests (which don't set PKGCLD_REPO_URL) don't fail at configuration time.
-        if (pkgcldRepoUrl) {
-            maven {
-                name = "PackageCloud"
-                url = uri(pkgcldRepoUrl)
-                authentication {
-                    header(HttpHeaderAuthentication)
-                }
-                credentials(HttpHeaderCredentials) {
-                    name = "Authorization"
-                    value = "Bearer " + (System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken"))
-                }
+        maven {
+            name = "PackageCloud"
+            url = uri(pkgcldRepoUrl)
+            authentication {
+                header(HttpHeaderAuthentication)
+            }
+            credentials(HttpHeaderCredentials) {
+                name = "Authorization"
+                value = "Bearer " + (System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken"))
             }
         }
     }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -5,18 +5,10 @@
  * publishDescription = 'description' (optional)
  * githubSlug = Github slug e.g. 'rundeck/rundeck-cli'
  * developers = [ [id:'id', name:'name', email: 'email' ] ] list of developers
- *
- * Define project properties to sign and publish when invoking publish task:
- *
- *     ./gradlew \
- *     -PsigningKey="base64 encoded gpg key" \
- *     -PsigningPassword="password for key" \
- *     -PsonatypeUsername="sonatype token user" \
- *     -PsonatypePassword="sonatype token password" \
- *     publishToSonatype closeAndReleaseSonatypeStagingRepository
  */
 apply plugin: 'maven-publish'
-apply plugin: 'signing'
+
+def pkgcldRepoUrl = System.getenv("PKGCLD_REPO_URL")?.trim()
 
 publishing {
     publications {
@@ -56,31 +48,20 @@ publishing {
         }
     }
     repositories {
-        def pkgcldWriteToken = System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken")
-        if (pkgcldWriteToken) {
+        // Only register the PackageCloud repo when its URL is configured, so plain
+        // builds/tests (which don't set PKGCLD_REPO_URL) don't fail at configuration time.
+        if (pkgcldRepoUrl) {
             maven {
-                name = "PackageCloudTest"
-                url = uri("https://packagecloud.io/pagerduty/rundeckpro-test/maven2")
+                name = "PackageCloud"
+                url = uri(pkgcldRepoUrl)
                 authentication {
                     header(HttpHeaderAuthentication)
                 }
                 credentials(HttpHeaderCredentials) {
                     name = "Authorization"
-                    value = "Bearer " + pkgcldWriteToken
+                    value = "Bearer " + (System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken"))
                 }
             }
         }
-    }
-}
-def base64Decode = { String prop ->
-    project.findProperty(prop) ?
-            new String(Base64.getDecoder().decode(project.findProperty(prop).toString())).trim() :
-            null
-}
-
-if (project.hasProperty('signingKey') && project.hasProperty('signingPassword')) {
-    signing {
-        useInMemoryPgpKeys(base64Decode("signingKey"), project.signingPassword)
-        sign(publishing.publications)
     }
 }


### PR DESCRIPTION
## Jira ticket

[RUN-4638](https://pagerduty.atlassian.net/browse/RUN-4638) (subtask of [RUN-4570](https://pagerduty.atlassian.net/browse/RUN-4570))

## Description

Migrate `aws-s3-model-source` publishing from Maven Central (Sonatype) to PackageCloud, applying the same design already validated on [rundeck-plugins/sshj-plugin#136](https://github.com/rundeck-plugins/sshj-plugin/pull/136), [rundeck-plugins/http-step#60](https://github.com/rundeck-plugins/http-step/pull/60), and [rundeck-plugins/ansible-plugin#456](https://github.com/rundeck-plugins/ansible-plugin/pull/456). Part of the RUN-4570 Maven Central publishing limits resolution — plugins account for the bulk of the file/release count on Maven Central, but no external project depends on them as Maven dependencies.

- Removed `nexusPublish`/`nexusPublishing` (Sonatype-specific, dead once `release.yml` stops calling `publishToSonatype`).
- Point the existing PackageCloud maven repo at the configurable `PKGCLD_REPO_URL` env var (trimmed, and guarded so plain builds/CI without the var don't fail at Gradle configuration time), replacing the hardcoded `rundeckpro-test` URL left over from an earlier test.
- Dropped GPG signing: PackageCloud's Maven endpoint rejects the checksum Gradle auto-generates for `.asc` signature files (422 Unprocessable Entity on `*.jar.asc.sha1`), and neither the OSS `rundeck` WAR nor `rundeckpro-enterprise` WAR carry `.asc` signatures on PackageCloud either — only RPM/DEB packages are signed there, natively, via the separately-published `BUILD-GPG-KEY`.
- `release.yml`: replaced the "Publish to Maven Central" step with "Publish to PackageCloud".

## Testing instructions

- Merge this PR.
- Tag a test version to trigger the release workflow (this exact flow — build, sign-free publish, checksums — was validated end-to-end on `sshj-plugin` 1.0.4: jar/pom/sources/javadoc all publish successfully to PackageCloud).
- Verify the artifact appears under `org/rundeck/plugins/aws-s3-model-source/<version>/` at whatever repo `PKGCLD_REPO_URL` points to.
- Verify `./gradlew build` still succeeds without `PKGCLD_REPO_URL` set (e.g. in `gradle.yml` CI) — the PackageCloud repo registration is guarded and should not affect plain builds.
